### PR TITLE
Dbp hotfix 03172022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ WORKDIR /opt/dcan-tools
 
 # dcan bold processing
 ADD https://github.com/DCAN-Labs/dcan_bold_processing.git version.json
-#RUN git clone -b v4.0.6 --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
-RUN git clone -b 'develop' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
+RUN git clone -b v4.0.10 --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
 
 # dcan executive summary
 RUN git clone -b v2.2.10 --single-branch --depth 1 https://github.com/DCAN-Labs/ExecutiveSummary.git executivesummary

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/dcan-tools
 # dcan bold processing
 ADD https://github.com/DCAN-Labs/dcan_bold_processing.git version.json
 #RUN git clone -b v4.0.6 --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
-RUN git clone -b v4.0.9 --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
+RUN git clone -b 'develop' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan_bold_processing.git dcan_bold_proc
 
 # dcan executive summary
 RUN git clone -b v2.2.10 --single-branch --depth 1 https://github.com/DCAN-Labs/ExecutiveSummary.git executivesummary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM dcanumn/external-software:v0.0.5
+FROM dcanumn/external-software:v0.0.4
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
         python2.7 \


### PR DESCRIPTION
Changelist from v1.0.7:

**ENH**: Update dcan_bold_proc to v4.0.10
**FIX**: Revert to external-software v0.0.4 (downgrade Matlab R2019a -> R2017a; fixes matlabpath error in dcan_bold_proc)
